### PR TITLE
Fix compatibility with Node 4.8

### DIFF
--- a/src/es6-transform.js
+++ b/src/es6-transform.js
@@ -7,9 +7,8 @@ module.exports = function(tree, babelOptions, options) {
   babelOptions = babelOptions || {};
   options = options || {};
   const defaultBabelOptions = {
-    getModuleId: function (moduleName) {
-      const moduleKey = moduleName + '.js';
-      const assetOptions = options[moduleKey];
+    getModuleId: function(moduleName) {
+      const assetOptions = options[`${moduleName}.js`];
       if (assetOptions) {
         return assetOptions.as;
       } else {

--- a/src/es6-transform.js
+++ b/src/es6-transform.js
@@ -3,10 +3,13 @@
 
 const BabelTranspiler = require('broccoli-babel-transpiler');
 
-module.exports = function(tree, babelOptions = {}, options = {}) {
+module.exports = function(tree, babelOptions, options) {
+  babelOptions = babelOptions || {};
+  options = options || {};
   const defaultBabelOptions = {
-    getModuleId: (moduleName) => {
-      const assetOptions = options[`${moduleName}.js`];
+    getModuleId: function (moduleName) {
+      const moduleKey = moduleName + '.js';
+      const assetOptions = options[moduleKey];
       if (assetOptions) {
         return assetOptions.as;
       } else {


### PR DESCRIPTION
I noticed you removed explicit NodeJS 4.x compatibility in a recent commit. 
My workstation at my employer has NodeJS 4.8.7.
One of the reasons we like EmberJS is because it maintains compatibility with Node 4.5+.
We need to install this plugin in our project, however after installing the plugin we get "Unexpected Token" errors when ember-cli tries to use this plugin.

The changes in this PR fix the problem for us. I recommend you consider including the changes to ensure broader compatibility for your users.